### PR TITLE
Tycho build configuration added for TempalteVariables eclipse plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target
+
+eclipse-target

--- a/mmm-eclipse/mmm-eclipse-templatevariables-feature/.project
+++ b/mmm-eclipse/mmm-eclipse-templatevariables-feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>net.sf.mmm.eclipse.templatevariables-feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/mmm-eclipse/mmm-eclipse-templatevariables-feature/build.properties
+++ b/mmm-eclipse/mmm-eclipse-templatevariables-feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/mmm-eclipse/mmm-eclipse-templatevariables-feature/feature.xml
+++ b/mmm-eclipse/mmm-eclipse-templatevariables-feature/feature.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="net.sf.mmm.eclipse.templatevariables.feature"
+      label="M-M-M-TemplateVariables"
+      version="1.0.0.qualifier"
+      provider-name="m-m-m">
+
+   <description>
+      TODO
+   </description>
+
+   <copyright>
+      TODO
+   </copyright>
+
+   <license>
+      TODO
+   </license>
+
+   <url>
+      <update label="TemplateVariables Update Site" url="TODO"/>
+      <discovery label="M-M-M TempalteVariables" url="TODO"/>
+   </url>
+
+   <plugin
+         id="net.sf.mmm.eclipse.templatevariables"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/mmm-eclipse/mmm-eclipse-templatevariables-feature/pom.xml
+++ b/mmm-eclipse/mmm-eclipse-templatevariables-feature/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>net.sf.m-m-m</groupId>
+    <artifactId>mmm-eclipse</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>net.sf.mmm.eclipse.templatevariables.feature</artifactId>
+  <packaging>eclipse-feature</packaging>
+
+</project>

--- a/mmm-eclipse/mmm-eclipse-templatevariables-updateSite/.project
+++ b/mmm-eclipse/mmm-eclipse-templatevariables-updateSite/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>net.sf.mmm.eclipse.templatevariables-updatesite</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.UpdateSiteBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.UpdateSiteNature</nature>
+	</natures>
+</projectDescription>

--- a/mmm-eclipse/mmm-eclipse-templatevariables-updateSite/category.xml
+++ b/mmm-eclipse/mmm-eclipse-templatevariables-updateSite/category.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site pack200="true" digestURL="http://www.agilereview.org/development_update/">
+   <feature url="features/net.sf.mmm.eclipse.templatevariables.feature_0.0.0.jar" id="net.sf.mmm.eclipse.templatevariables.feature" version="0.0.0">
+      <category name="net.sf.mmm.eclipse.templatevariables.updates"/>
+   </feature>
+   <category-def name="net.sf.mmm.eclipse.updates" label="M-M-M Tools"/>
+</site>

--- a/mmm-eclipse/mmm-eclipse-templatevariables-updateSite/pom.xml
+++ b/mmm-eclipse/mmm-eclipse-templatevariables-updateSite/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>net.sf.m-m-m</groupId>
+    <artifactId>mmm-eclipse</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>net.sf.mmm.eclipse.templatevariables.updatesite</artifactId>
+  <packaging>eclipse-repository</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <archiveSite>true</archiveSite>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/mmm-eclipse/mmm-eclipse-templatevariables/.classpath
+++ b/mmm-eclipse/mmm-eclipse-templatevariables/.classpath
@@ -1,0 +1,6 @@
+<classpath>
+  <classpathentry kind="src" path="src/main/java" including="**/*.java"/>
+  <classpathentry kind="output" path="eclipse-target/classes"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+  <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+</classpath>

--- a/mmm-eclipse/mmm-eclipse-templatevariables/.project
+++ b/mmm-eclipse/mmm-eclipse-templatevariables/.project
@@ -1,0 +1,20 @@
+<projectDescription>
+  <name>net.sf.mmm.eclipse.templatevariables</name>
+  <comment>Eclipse plugin to register additional variables for java templates like project_version. NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
+  <projects/>
+  <buildSpec>
+    <buildCommand>
+      <name>org.eclipse.jdt.core.javabuilder</name>
+    </buildCommand>
+    <buildCommand>
+      <name>org.eclipse.pde.ManifestBuilder</name>
+    </buildCommand>
+    <buildCommand>
+      <name>org.eclipse.pde.SchemaBuilder</name>
+    </buildCommand>
+  </buildSpec>
+  <natures>
+    <nature>org.eclipse.jdt.core.javanature</nature>
+    <nature>org.eclipse.pde.PluginNature</nature>
+  </natures>
+</projectDescription>

--- a/mmm-eclipse/mmm-eclipse-templatevariables/META-INF/MANIFEST.MF
+++ b/mmm-eclipse/mmm-eclipse-templatevariables/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: TemplateVariables
+Bundle-Name: net.sf.mmm.eclipse.templatevariables
 Bundle-SymbolicName: net.sf.mmm.eclipse.templatevariables;singleton:=true
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: net.sf.mmm.eclipse.templatevariables.Activator
 Bundle-Vendor: Jörg Hohwiller
 Require-Bundle: org.eclipse.ui,
@@ -13,7 +13,5 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.jface.text,
  org.eclipse.core.variables
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6,
- JavaSE-1.7,
- J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy

--- a/mmm-eclipse/mmm-eclipse-templatevariables/build.properties
+++ b/mmm-eclipse/mmm-eclipse-templatevariables/build.properties
@@ -1,7 +1,6 @@
-source.. = src/main/java,\
-           src/main/resources
-output.. = target/classes
+source.. = src/main/java
+output.. = eclipse-target/classes
 bin.includes = plugin.xml,\
                META-INF/,\
-               .,\
-               icons/
+               .
+jre.compilation.profile = JavaSE-1.7

--- a/mmm-eclipse/mmm-eclipse-templatevariables/pom.xml
+++ b/mmm-eclipse/mmm-eclipse-templatevariables/pom.xml
@@ -5,67 +5,13 @@
   <parent>
     <groupId>net.sf.m-m-m</groupId>
     <artifactId>mmm-eclipse</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>mmm-eclipse-templatevariables</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+
+  <artifactId>net.sf.mmm.eclipse.templatevariables</artifactId>
   <packaging>eclipse-plugin</packaging>
   <name>${project.artifactId}</name>
   <description>Eclipse plugin to register additional variables for java templates like project_version.</description>
-  <!--
-  <dependencies>
-    <dependency>
-      <groupId>org.eclipse.ui</groupId>
-      <artifactId>org.eclipse.ui</artifactId>
-      <version>3.104.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.core</groupId>
-      <artifactId>org.eclipse.core.runtime</artifactId>
-      <version>3.8.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.m2e</groupId>
-      <artifactId>org.eclipse.m2e.core</artifactId>
-      <version>1.2.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jdt</groupId>
-      <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.8.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jdt</groupId>
-      <artifactId>org.eclipse.jdt.ui</artifactId>
-      <version>3.8.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.core</groupId>
-      <artifactId>org.eclipse.core.resources</artifactId>
-      <version>3.8.1</version>
-    </dependency>
-  </dependencies>
-  -->
-  <!--
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>1.4.0</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>net.sf.mmm.eclipse.templatevariables</Bundle-SymbolicName>
-            <Bundle-Name>TemplateVariables</Bundle-Name>
-            <Bundle-Version>${project.version}</Bundle-Version>
-            <Bundle-Activator>net.sf.mmm.eclipse.templatevariables.Activator</Bundle-Activator>
-            <Private-Package>net.sf.mmm.eclipse.templatevariables</Private-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-  -->
+
 </project>

--- a/mmm-eclipse/pom.xml
+++ b/mmm-eclipse/pom.xml
@@ -8,45 +8,130 @@
     <version>1.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <!--
-  <parent>
-    <groupId>org.eclipse</groupId>
-    <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.3.0</version>
-  </parent>
-  -->
+
   <artifactId>mmm-eclipse</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
   <description>Eclipse plugins created by the mmm project.</description>
+
+  <properties>
+    <tycho.version>0.22.0</tycho.version>
+    <tycho-extras.version>0.22.0</tycho-extras.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <tycho-repo.url>https://oss.sonatype.org/content/groups/public/</tycho-repo.url>
+    <eclipse-repo.url>http://download.eclipse.org/releases/juno</eclipse-repo.url>
+  </properties>
+
   <modules>
     <module>mmm-eclipse-templatevariables</module>
+    <module>mmm-eclipse-templatevariables-feature</module>
+    <module>mmm-eclipse-templatevariables-updateSite</module>
   </modules>
+
+  <!-- Tycho Build -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <extensions>true</extensions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <environments>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86</arch>
+            </environment>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>x86</arch>
+            </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>macosx</os>
+              <ws>cocoa</ws>
+              <arch>x86_64</arch>
+            </environment>
+          </environments>
+        </configuration>
+      </plugin>
+	  <!-- Skip maven-eclipse-plugin as we developing with using the Manifest-First approach -->
+	  <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-eclipse-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>target-platform-configuration</artifactId>
+          <version>${tycho.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-compiler-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <compilerArguments>
+              <inlineJSR/>
+              <enableJavadoc/>
+              <encoding>${project.build.sourceEncoding}</encoding>
+            </compilerArguments>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <baselineMode>warn</baselineMode>
+            <baselineReplace>none</baselineReplace>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <repositories>
     <repository>
+      <id>eclipse platform</id>
+      <layout>p2</layout>
+      <url>${eclipse-repo.url}</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>tycho</id>
+      <url>${tycho-repo.url}</url>
       <releases>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
       </releases>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-      <id>eclipse-hosted</id>
-      <url>https://repo.eclipse.org/content/repositories/eclipse/</url>
-    </repository>
-    <repository>
-      <id>eclipse</id>
-      <url>https://repo.eclipse.org/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-  <build>
-    <plugins>
-       <plugin>
-         <groupId>org.eclipse.tycho</groupId>
-         <artifactId>tycho-maven-plugin</artifactId>
-         <version>0.17.0</version>
-         <extensions>true</extensions>
-       </plugin>
-    </plugins>
-  </build>
+    </pluginRepository>
+  </pluginRepositories>
+
 </project>


### PR DESCRIPTION
I have added a root configuration for building your eclipse plug-in as discussed.
There are some TODOs for you left in the `mmm-eclipse/mmm-eclipse-templatevariables-feature/feature.xml` you might want to solve before releasing.

I pushed the eclipse configuration as you might want to develop your plug-in in a manifest-first approach, which is much more easier as pom-first. Therefore, I also disabled the maven-eclipse-plugin for the mmm-eclipse maven subtree to not result in destroyed configurations accidentially.

You can now simply build a new version of your plug-in running `mvn package` on the `mmm-eclipse` parent. You will then find the packed eclipse update-site of your plug-in in the `*.updatesite/eclipse-target` folder.

Happy eclipse plug-in development ;)
If you like to know more about automatically uploading your build to the cloud via maven, just contact me or have a look at the [wagon configuration of AgileReview](https://github.com/AgileReview-Project/AgileReview-Legacy-Plugin/blob/next_Release/pom.xml).